### PR TITLE
refactor: update convert_date_to_text to return None when invalid input

### DIFF
--- a/brutils/date.py
+++ b/brutils/date.py
@@ -6,7 +6,7 @@ from num2words import num2words
 from brutils.data.enums.months import MonthsEnum
 
 
-def convert_date_to_text(date: str) -> Union[str, None]:
+def convert_date_to_text(date: str) -> str | None:
     """
     Converts a given date in Brazilian format (dd/mm/yyyy) to its textual representation.
 
@@ -24,9 +24,7 @@ def convert_date_to_text(date: str) -> Union[str, None]:
     """
     pattern = re.compile(r"\d{2}/\d{2}/\d{4}")
     if not re.match(pattern, date):
-        raise ValueError(
-            "Date is not a valid date. Please pass a date in the format dd/mm/yyyy."
-        )
+        return None
 
     day_str, month_str, year_str = date.split("/")
     day = int(day_str)

--- a/brutils/date.py
+++ b/brutils/date.py
@@ -1,5 +1,4 @@
 import re
-from typing import Union
 
 from num2words import num2words
 

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -45,10 +45,10 @@ class TestDate(TestCase):
         self.assertIsNone(convert_date_to_text("29/02/2019"), None)
 
         # Invalid date pattern.
-        self.assertRaises(ValueError, convert_date_to_text, "Invalid")
-        self.assertRaises(ValueError, convert_date_to_text, "25/1/2020")
-        self.assertRaises(ValueError, convert_date_to_text, "1924/08/20")
-        self.assertRaises(ValueError, convert_date_to_text, "5/09/2020")
+        self.assertIsNone(convert_date_to_text("Invalid"))
+        self.assertIsNone(convert_date_to_text("25/1/2020"))
+        self.assertIsNone(convert_date_to_text("1924/08/20"))
+        self.assertIsNone(convert_date_to_text("5/09/2020"))
 
         self.assertEqual(
             convert_date_to_text("29/02/2020"),


### PR DESCRIPTION
## Descrição
<!--- Descreva de forma sucinta e clara qual é o propósito deste Pull Request. Explique o que ele faz ou resolve.-->
A função `convert_date_to_text` não estava seguindo o padrão de retornar `None` quando um input é inválido.

## Mudanças Propostas
<!--- Liste as principais alterações ou melhorias que estão sendo propostas neste Pull Request.

- Exemplo 1: Descrição da primeira alteração.
- Exemplo 2: Descrição da segunda alteração.
- ...-->

## Checklist de Revisão
<!--- Marque as caixas que se aplicam. Você pode deixar caixas desmarcadas se elas não se aplicarem.-->

- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.

## Comentários Adicionais (opcional)
<!--- Adicione qualquer informação adicional ou contexto que você acha importante para os revisores entenderem suas mudanças.-->

## Issue Relacionada
<!---Todos os PRs devem ter uma issue relacionada. Dessa forma, podemos garantir que ninguém perca tempo trabalhando em algo que não precisa ser feito. -->

Closes #568
