### PR TITLE
feat(cnh): add CNH validation and cleaning + unittest (closes #578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `format_currency` [#434](https://github.com/brazilian-utils/brutils-python/pull/434)
 - Utilitário `convert_real_to_text` [#525](https://github.com/brazilian-utils/brutils-python/pull/525)
 - Utilitário `convert_uf_to_name` [#554](https://github.com/brazilian-utils/brutils-python/pull/554)
+- Utilitário `is_valid_cnh` [#578](https://github.com/brazilian-utils/brutils-python/pull/578)
+- Utilitário `remove_symbols_cnh` [#578](https://github.com/brazilian-utils/brutils-python/pull/578)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -1322,12 +1322,12 @@ None
 
 Retorna se os dígitos verificadores da CNH fornecida correspondem ao seu número base.
 
-**Observações:**
+Observações:
 
-- Esta função **não** consulta bases oficiais (BINCO/SENATRAN). Ela apenas realiza a validação aritmética dos dígitos verificadores (pré-validação).
+- Esta função não consulta bases oficiais (BINCO/SENATRAN). Ela apenas realiza a validação aritmética dos dígitos verificadores (pré-validação).
 - Rejeita sequências onde todos os dígitos são iguais.
 
-**Regras (módulo 11 – prática comum em documentos brasileiros):**
+Regras (módulo 11 – prática comum em documentos brasileiros):
 
 1) Considere os 9 primeiros dígitos como base.  
 2) Primeiro dígito verificador (10º dígito):  
@@ -1337,15 +1337,15 @@ Retorna se os dígitos verificadores da CNH fornecida correspondem ao seu númer
    `soma2 = Σ base[i] * peso crescente (1..9) + dv1 * 2`  
    `dv2 = soma2 % 11; se dv2 >= 10 → dv2 = 0`
 
-**Argumentos:**
+Argumentos:
 
 - `cnh (str | None)`: String da CNH com 11 dígitos (símbolos serão ignorados).
 
-**Retorna:**
+Retorna:
 
 - `bool`: `True` se os dígitos verificadores forem consistentes, `False` caso contrário.
 
-**Exemplo:**
+Exemplo:
 
 ```python
 >>> from brutils import is_valid_cnh
@@ -1363,15 +1363,15 @@ False
 
 Remove qualquer caractere que não seja dígito de uma CNH.
 
-**Argumentos:**
+Argumentos:
 
 * `cnh (str | None)`: String contendo a CNH com ou sem símbolos.
 
-**Retorna:**
+Retorna:
 
 * `str | None`: A CNH contendo apenas dígitos, ou `None` se a entrada for inválida.
 
-**Exemplo:**
+Exemplo:
 
 ```python
 >>> from brutils import remove_symbols_cnh

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ False
 - [Monetário](#monetário)
   - [format\_currency](#format_currency)
   - [convert\_real\_to\_text](#convert_real_to_text)
+- [CNH](#cnh)
+  - [is\_valid\_cnh](#is_valid_cnh)
+  - [remove\_symbols\_cnh](#remove_symbols_cnh)
 
 ## CPF
 
@@ -1310,6 +1313,73 @@ Exemplo:
 >>> convert_real_to_text(-50.25)
 'Menos cinquenta reais e vinte e cinco centavos'
 >>> convert_real_to_text("invalid")
+None
+```
+
+## CNH
+
+### is_valid_cnh
+
+Retorna se os dígitos verificadores da CNH fornecida correspondem ao seu número base.
+
+**Observações:**
+
+- Esta função **não** consulta bases oficiais (BINCO/SENATRAN). Ela apenas realiza a validação aritmética dos dígitos verificadores (pré-validação).
+- Rejeita sequências onde todos os dígitos são iguais.
+
+**Regras (módulo 11 – prática comum em documentos brasileiros):**
+
+1) Considere os 9 primeiros dígitos como base.  
+2) Primeiro dígito verificador (10º dígito):  
+   `soma1 = Σ base[i] * peso decrescente (9..1)`  
+   `dv1 = soma1 % 11; se dv1 >= 10 → dv1 = 0`  
+3) Segundo dígito verificador (11º dígito):  
+   `soma2 = Σ base[i] * peso crescente (1..9) + dv1 * 2`  
+   `dv2 = soma2 % 11; se dv2 >= 10 → dv2 = 0`
+
+**Argumentos:**
+
+- `cnh (str | None)`: String da CNH com 11 dígitos (símbolos serão ignorados).
+
+**Retorna:**
+
+- `bool`: `True` se os dígitos verificadores forem consistentes, `False` caso contrário.
+
+**Exemplo:**
+
+```python
+>>> from brutils import is_valid_cnh
+>>> is_valid_cnh("270.694.311-77")
+True
+>>> is_valid_cnh("27069431170")  # dígito verificador alterado
+False
+>>> is_valid_cnh("11111111111")  # dígitos repetidos
+False
+>>> is_valid_cnh("123")          # tamanho inválido
+False
+```
+
+### remove_symbols_cnh
+
+Remove qualquer caractere que não seja dígito de uma CNH.
+
+**Argumentos:**
+
+* `cnh (str | None)`: String contendo a CNH com ou sem símbolos.
+
+**Retorna:**
+
+* `str | None`: A CNH contendo apenas dígitos, ou `None` se a entrada for inválida.
+
+**Exemplo:**
+
+```python
+>>> from brutils import remove_symbols_cnh
+>>> remove_symbols_cnh("270.694.311-77")
+'27069431177'
+>>> remove_symbols_cnh(None)
+None
+>>> remove_symbols_cnh(12345678901)  # não é string
 None
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1342,15 +1342,15 @@ Rules (modulo 11 – common practice in Brazilian documents):
    `sum2 = Σ base[i] * increasing weight (1..9) + dv1 * 2`  
    `dv2 = sum2 % 11; if dv2 >= 10 → dv2 = 0`
 
-**Args:**
+Args:
 
 - `cnh (str | None)`: CNH string with 11 digits (symbols will be ignored).
 
-**Returns:**
+Returns:
 
 - `bool`: `True` if the check digits are consistent, `False` otherwise.
 
-**Example:**
+Example:
 
 ```python
 >>> from brutils import is_valid_cnh
@@ -1368,15 +1368,15 @@ False
 
 Removes any character that is not a digit from a CNH.
 
-**Args:**
+Args:
 
 * `cnh (str | None)`: String containing the CNH with or without symbols.
 
-**Returns:**
+Returns:
 
 * `str | None`: The CNH containing only digits, or `None` if the input is invalid.
 
-**Example:**
+Example:
 
 ```python
 >>> from brutils import remove_symbols_cnh

--- a/README_EN.md
+++ b/README_EN.md
@@ -99,6 +99,9 @@ False
 - [Monetary](#monetary)
   - [format_currency](#format_currency)
   - [convert\_real\_to\_text](#convert_real_to_text)
+- [CNH](#cnh)
+  - [is\_valid\_cnh](#is_valid_cnh)
+  - [remove\_symbols\_cnh](#remove_symbols_cnh)
 
 ## CPF
 
@@ -1315,6 +1318,73 @@ Example:
 >>> convert_real_to_text(-50.25)
 'Menos cinquenta reais e vinte e cinco centavos'
 >>> convert_real_to_text("invalid")
+None
+```
+
+## CNH
+
+### is_valid_cnh
+
+Returns whether the check digits of the provided CNH match its base number.
+
+Notes:
+
+- This function does not query official databases (BINCO/SENATRAN). It only performs the arithmetic validation of the check digits (pre-validation).
+- Rejects sequences where all digits are the same.
+
+Rules (modulo 11 – common practice in Brazilian documents):
+
+1) Consider the first 9 digits as the base.  
+2) First check digit (10th digit):  
+   `sum1 = Σ base[i] * decreasing weight (9..1)`  
+   `dv1 = sum1 % 11; if dv1 >= 10 → dv1 = 0`  
+3) Second check digit (11th digit):  
+   `sum2 = Σ base[i] * increasing weight (1..9) + dv1 * 2`  
+   `dv2 = sum2 % 11; if dv2 >= 10 → dv2 = 0`
+
+**Args:**
+
+- `cnh (str | None)`: CNH string with 11 digits (symbols will be ignored).
+
+**Returns:**
+
+- `bool`: `True` if the check digits are consistent, `False` otherwise.
+
+**Example:**
+
+```python
+>>> from brutils import is_valid_cnh
+>>> is_valid_cnh("270.694.311-77")
+True
+>>> is_valid_cnh("27069431170")  # changed check digit
+False
+>>> is_valid_cnh("11111111111")  # repeated digits
+False
+>>> is_valid_cnh("123")          # wrong length
+False
+```
+
+### remove_symbols_cnh
+
+Removes any character that is not a digit from a CNH.
+
+**Args:**
+
+* `cnh (str | None)`: String containing the CNH with or without symbols.
+
+**Returns:**
+
+* `str | None`: The CNH containing only digits, or `None` if the input is invalid.
+
+**Example:**
+
+```python
+>>> from brutils import remove_symbols_cnh
+>>> remove_symbols_cnh("270.694.311-77")
+'27069431177'
+>>> remove_symbols_cnh(None)
+None
+>>> remove_symbols_cnh(12345678901)  # not a string
 None
 ```
 

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -8,6 +8,9 @@ from brutils.cep import generate as generate_cep
 from brutils.cep import is_valid as is_valid_cep
 from brutils.cep import remove_symbols as remove_symbols_cep
 
+# CNH Imports
+from brutils.cnh import is_valid_cnh, remove_symbols_cnh
+
 # CNPJ Imports
 from brutils.cnpj import format_cnpj
 from brutils.cnpj import generate as generate_cnpj
@@ -131,4 +134,7 @@ __all__ = [
     # Currency
     "format_currency",
     "convert_real_to_text",
+    # CNH
+    "is_valid_cnh",
+    "remove_symbols_cnh",
 ]

--- a/brutils/cnh.py
+++ b/brutils/cnh.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import re
+from typing import Final
+
+__all__ = ["is_valid_cnh", "remove_symbols_cnh"]
+
+_DIGITS_RE: Final = re.compile(r"\D+")
+
+
+def remove_symbols_cnh(cnh: str | None) -> str | None:
+    """
+    Removes any character that is not a digit from a CNH.
+
+    Args:
+        cnh (str | None): String containing the CNH with or without symbols.
+
+    Returns:
+        str | None: The CNH containing only digits, or None if the input is invalid.
+    """
+    if not isinstance(cnh, str):
+        return None
+    return _DIGITS_RE.sub("", cnh)
+
+
+def is_valid_cnh(cnh: str | None) -> bool:
+    """
+    Returns whether the check digits of the provided CNH match its base number.
+
+    Notes:
+    - This function does not query official databases (BINCO/SENATRAN). It only performs
+    the arithmetic validation of the check digits (pre-validation).
+    - Rejects sequences where all digits are the same.
+
+    Rules (modulo 11 – common practice in Brazilian documents):
+    1) Consider the first 9 digits as the base.
+    2) First check digit (10th digit):
+        sum1 = Σ base[i] * decreasing weight (9..1)
+        dv1 = sum1 % 11; if dv1 >= 10 → dv1 = 0
+    3) Second check digit (11th digit):
+        sum2 = Σ base[i] * increasing weight (1..9) + dv1 * 2
+        dv2 = sum2 % 11; if dv2 >= 10 → dv2 = 0
+
+    Args:
+        cnh (str | None): CNH string with 11 digits (symbols will be ignored).
+
+    Returns:
+        bool: True if the check digits are consistent, False otherwise.
+    """
+    digits_only = remove_symbols_cnh(cnh)
+    if not digits_only or len(digits_only) != 11 or not digits_only.isdigit():
+        return False
+
+    # reject sequences like 000..., 111..., etc.
+    if digits_only == digits_only[0] * 11:
+        return False
+
+    nums = [int(ch) for ch in digits_only]
+
+    # base: first 9 digits
+    base = nums[:9]
+    dv_expected_1 = nums[9]
+    dv_expected_2 = nums[10]
+
+    # first check digit: weights 9..1
+    soma1 = sum(d * w for d, w in zip(base, range(9, 0, -1)))
+    dv1 = soma1 % 11
+    if dv1 >= 10:
+        dv1 = 0
+
+    # second check digit: weights 1..9 + dv1*2
+    soma2 = sum(d * w for d, w in zip(base, range(1, 10))) + dv1 * 2
+    dv2 = soma2 % 11
+    if dv2 >= 10:
+        dv2 = 0
+
+    return dv1 == dv_expected_1 and dv2 == dv_expected_2

--- a/tests/test_cnh.py
+++ b/tests/test_cnh.py
@@ -1,0 +1,82 @@
+from unittest import TestCase, main
+
+from brutils.cnh import is_valid_cnh, remove_symbols_cnh
+
+
+class TestCNH(TestCase):
+    def test_remove_symbols_cnh_ok(self):
+        cases = [
+            ("123.456.789-00", "12345678900"),
+            ("  053.180.594-10  ", "05318059410"),
+            ("41010881538", "41010881538"),
+            ("", ""),  # empty string remains empty
+            ("abc", ""),  # no digits → empty string
+            ("--93-825.480-731--", "93825480731"),
+        ]
+        for raw, expected in cases:
+            with self.subTest(raw=raw):
+                self.assertEqual(remove_symbols_cnh(raw), expected)
+
+    def test_remove_symbols_cnh_invalid_types(self):
+        invalid_inputs = [None, 123, 12.3, object()]
+        for invalid in invalid_inputs:
+            with self.subTest(invalid=invalid):
+                self.assertIsNone(remove_symbols_cnh(invalid))
+
+    def test_is_valid_cnh_true_digits_only(self):
+        valid_cases = [
+            "05318059410",
+            "41010881538",
+            "55541187371",
+            "89134024277",
+            "93825480731",
+        ]
+        for cnh in valid_cases:
+            with self.subTest(cnh=cnh):
+                self.assertTrue(is_valid_cnh(cnh))
+
+    def test_is_valid_cnh_true_with_symbols(self):
+        formatted_cases = [
+            "053.180.594-10",
+            "410.108.815-38",
+            "555.411.873-71",
+            "891.340.242-77",
+            "938.254.807-31",
+        ]
+        for cnh in formatted_cases:
+            with self.subTest(cnh=cnh):
+                self.assertTrue(is_valid_cnh(cnh))
+
+    def test_is_valid_cnh_false(self):
+        invalid_cases = [
+            # repeated digit sequences
+            "00000000000",
+            "11111111111",
+            "22222222222",
+            # invalid length
+            "1234567890",  # 10 digits
+            "123456789012",  # 12 digits
+            # non-numeric after cleaning
+            "abc",
+            "",
+            # wrong check digit
+            "05318059411",  # last digit changed
+            "41010881530",  # last digit changed
+        ]
+        for cnh in invalid_cases:
+            with self.subTest(cnh=cnh):
+                self.assertFalse(is_valid_cnh(cnh))
+
+    def test_is_valid_cnh_none_input(self):
+        self.assertFalse(is_valid_cnh(None))
+
+    def test_pipeline_remove_then_validate(self):
+        """Full pipeline: remove symbols then validate."""
+        raw = " 053.180.594-10 "
+        cleaned = remove_symbols_cnh(raw)
+        self.assertEqual(cleaned, "05318059410")
+        self.assertTrue(is_valid_cnh(cleaned))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Descrição
Adiciona duas funções ao módulo `brutils.cnh`:

* `remove_symbols_cnh`: remove caracteres não numéricos.
* `is_valid_cnh`: valida CNH (11 dígitos) via regra de módulo 11, aceitando entradas com símbolos e rejeitando sequências repetidas.

Inclui suíte de testes em unittest cobrindo casos válidos, inválidos, formatados e pipeline limpeza→validação.

## Mudanças Propostas
* **Novo**: `brutils/cnh.py` com `remove_symbols_cnh` e `is_valid_cnh`.
* **Novo**: `tests/test_cnh.py` (unittest).
* **Docs**: exemplos de uso nas docstrings.

## Checklist de Revisão
- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.

## Issue Relacionada
Closes [#578](https://github.com/brazilian-utils/brutils-python/issues/578)
