### PR TITLE
feat(cnh): add CNH validation and cleaning + unittest (closes #578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `format_currency` [#434](https://github.com/brazilian-utils/brutils-python/pull/434)
 - Utilitário `convert_real_to_text` [#525](https://github.com/brazilian-utils/brutils-python/pull/525)
 - Utilitário `convert_uf_to_name` [#554](https://github.com/brazilian-utils/brutils-python/pull/554)
+- Utilitário `is_valid_cnh` [#578](https://github.com/brazilian-utils/brutils-python/pull/578)
+- Utilitário `remove_symbols_cnh` [#578](https://github.com/brazilian-utils/brutils-python/pull/578)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -1371,7 +1371,7 @@ Retorna:
 Exemplo:
 
 ```python
->>> from brutils import remove_symbols_cnh
+>>> from brutils.cnh import remove_symbols_cnh
 >>> remove_symbols_cnh("270.694.311-77")
 '27069431177'
 >>> remove_symbols_cnh(None)

--- a/README.md
+++ b/README.md
@@ -1322,12 +1322,12 @@ None
 
 Retorna se os dígitos verificadores da CNH fornecida correspondem ao seu número base.
 
-**Observações:**
+Observações:
 
-- Esta função **não** consulta bases oficiais (BINCO/SENATRAN). Ela apenas realiza a validação aritmética dos dígitos verificadores (pré-validação).
+- Esta função não consulta bases oficiais (BINCO/SENATRAN). Ela apenas realiza a validação aritmética dos dígitos verificadores (pré-validação).
 - Rejeita sequências onde todos os dígitos são iguais.
 
-**Regras (módulo 11 – prática comum em documentos brasileiros):**
+Regras (módulo 11 – prática comum em documentos brasileiros):
 
 1) Considere os 9 primeiros dígitos como base.  
 2) Primeiro dígito verificador (10º dígito):  
@@ -1337,15 +1337,15 @@ Retorna se os dígitos verificadores da CNH fornecida correspondem ao seu númer
    `soma2 = Σ base[i] * peso crescente (1..9) + dv1 * 2`  
    `dv2 = soma2 % 11; se dv2 >= 10 → dv2 = 0`
 
-**Argumentos:**
+Argumentos:
 
 - `cnh (str | None)`: String da CNH com 11 dígitos (símbolos serão ignorados).
 
-**Retorna:**
+Retorna:
 
 - `bool`: `True` se os dígitos verificadores forem consistentes, `False` caso contrário.
 
-**Exemplo:**
+Exemplo:
 
 ```python
 >>> from brutils import is_valid_cnh
@@ -1363,15 +1363,15 @@ False
 
 Remove qualquer caractere que não seja dígito de uma CNH.
 
-**Argumentos:**
+Argumentos:
 
 * `cnh (str | None)`: String contendo a CNH com ou sem símbolos.
 
-**Retorna:**
+Retorna:
 
 * `str | None`: A CNH contendo apenas dígitos, ou `None` se a entrada for inválida.
 
-**Exemplo:**
+Exemplo:
 
 ```python
 >>> from brutils import remove_symbols_cnh

--- a/README.md
+++ b/README.md
@@ -1340,24 +1340,18 @@ Retorna:
 Exemplo:
 
 ```python
-from brutils.cnh import is_valid_cnh
-
-is_valid_cnh("02926434554")
+>>> from brutils.cnh import is_valid_cnh
+>>> is_valid_cnh("02926434554")
 True
-
-is_valid_cnh("12345678900")
+>>> is_valid_cnh("12345678900")
 True
-
-is_valid_cnh("11111111111")
+>>> is_valid_cnh("11111111111")
 False
-
-is_valid_cnh("029.264.345-54")
+>>> is_valid_cnh("029.264.345-54")
 True
-
-is_valid_cnh("12345678")
+>>> is_valid_cnh("12345678")
 False
-
-is_valid_cnh(None)
+>>> is_valid_cnh(None)
 False
 
 ```

--- a/README.md
+++ b/README.md
@@ -1320,43 +1320,46 @@ None
 
 ### is_valid_cnh
 
-Retorna se os dígitos verificadores da CNH fornecida correspondem ao seu número base.
+Retorna se a CNH fornecida atende às regras básicas de formatação.
 
 Observações:
 
-- Esta função não consulta bases oficiais (BINCO/SENATRAN). Ela apenas realiza a validação aritmética dos dígitos verificadores (pré-validação).
+- Esta função não consulta bases oficiais (Detran/Senatran).
+- Não realiza cálculo de dígitos verificadores.
 - Rejeita sequências onde todos os dígitos são iguais.
-
-Regras (módulo 11 – prática comum em documentos brasileiros):
-
-1) Considere os 9 primeiros dígitos como base.  
-2) Primeiro dígito verificador (10º dígito):  
-   `soma1 = Σ base[i] * peso decrescente (9..1)`  
-   `dv1 = soma1 % 11; se dv1 >= 10 → dv1 = 0`  
-3) Segundo dígito verificador (11º dígito):  
-   `soma2 = Σ base[i] * peso crescente (1..9) + dv1 * 2`  
-   `dv2 = soma2 % 11; se dv2 >= 10 → dv2 = 0`
+- Ignora símbolos comuns (pontos, hífens, espaços).
 
 Argumentos:
 
-- `cnh (str | None)`: String da CNH com 11 dígitos (símbolos serão ignorados).
+- `cnh (str | None)`: String da CNH (com ou sem símbolos).
 
 Retorna:
 
-- `bool`: `True` se os dígitos verificadores forem consistentes, `False` caso contrário.
+- `bool`: `True` se tiver 11 dígitos numéricos válidos e não for uma sequência repetida, `False` caso contrário.
 
 Exemplo:
 
 ```python
->>> from brutils import is_valid_cnh
->>> is_valid_cnh("270.694.311-77")
+from brutils.cnh import is_valid_cnh
+
+is_valid_cnh("02926434554")
 True
->>> is_valid_cnh("27069431170")  # dígito verificador alterado
+
+is_valid_cnh("12345678900")
+True
+
+is_valid_cnh("11111111111")
 False
->>> is_valid_cnh("11111111111")  # dígitos repetidos
+
+is_valid_cnh("029.264.345-54")
+True
+
+is_valid_cnh("12345678")
 False
->>> is_valid_cnh("123")          # tamanho inválido
+
+is_valid_cnh(None)
 False
+
 ```
 
 ### remove_symbols_cnh

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ False
 - [Monetário](#monetário)
   - [format\_currency](#format_currency)
   - [convert\_real\_to\_text](#convert_real_to_text)
+- [CNH](#cnh)
+  - [is\_valid\_cnh](#is_valid_cnh)
+  - [remove\_symbols\_cnh](#remove_symbols_cnh)
 
 ## CPF
 
@@ -1310,6 +1313,73 @@ Exemplo:
 >>> convert_real_to_text(-50.25)
 'Menos cinquenta reais e vinte e cinco centavos'
 >>> convert_real_to_text("invalid")
+None
+```
+
+## CNH
+
+### is_valid_cnh
+
+Retorna se os dígitos verificadores da CNH fornecida correspondem ao seu número base.
+
+**Observações:**
+
+- Esta função **não** consulta bases oficiais (BINCO/SENATRAN). Ela apenas realiza a validação aritmética dos dígitos verificadores (pré-validação).
+- Rejeita sequências onde todos os dígitos são iguais.
+
+**Regras (módulo 11 – prática comum em documentos brasileiros):**
+
+1) Considere os 9 primeiros dígitos como base.  
+2) Primeiro dígito verificador (10º dígito):  
+   `soma1 = Σ base[i] * peso decrescente (9..1)`  
+   `dv1 = soma1 % 11; se dv1 >= 10 → dv1 = 0`  
+3) Segundo dígito verificador (11º dígito):  
+   `soma2 = Σ base[i] * peso crescente (1..9) + dv1 * 2`  
+   `dv2 = soma2 % 11; se dv2 >= 10 → dv2 = 0`
+
+**Argumentos:**
+
+- `cnh (str | None)`: String da CNH com 11 dígitos (símbolos serão ignorados).
+
+**Retorna:**
+
+- `bool`: `True` se os dígitos verificadores forem consistentes, `False` caso contrário.
+
+**Exemplo:**
+
+```python
+>>> from brutils import is_valid_cnh
+>>> is_valid_cnh("270.694.311-77")
+True
+>>> is_valid_cnh("27069431170")  # dígito verificador alterado
+False
+>>> is_valid_cnh("11111111111")  # dígitos repetidos
+False
+>>> is_valid_cnh("123")          # tamanho inválido
+False
+```
+
+### remove_symbols_cnh
+
+Remove qualquer caractere que não seja dígito de uma CNH.
+
+**Argumentos:**
+
+* `cnh (str | None)`: String contendo a CNH com ou sem símbolos.
+
+**Retorna:**
+
+* `str | None`: A CNH contendo apenas dígitos, ou `None` se a entrada for inválida.
+
+**Exemplo:**
+
+```python
+>>> from brutils import remove_symbols_cnh
+>>> remove_symbols_cnh("270.694.311-77")
+'27069431177'
+>>> remove_symbols_cnh(None)
+None
+>>> remove_symbols_cnh(12345678901)  # não é string
 None
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1374,7 +1374,7 @@ Returns:
 Example:
 
 ```python
->>> from brutils import remove_symbols_cnh
+>>> from brutils.cnh import remove_symbols_cnh
 >>> remove_symbols_cnh("270.694.311-77")
 '27069431177'
 >>> remove_symbols_cnh(None)

--- a/README_EN.md
+++ b/README_EN.md
@@ -1342,15 +1342,15 @@ Rules (modulo 11 – common practice in Brazilian documents):
    `sum2 = Σ base[i] * increasing weight (1..9) + dv1 * 2`  
    `dv2 = sum2 % 11; if dv2 >= 10 → dv2 = 0`
 
-**Args:**
+Args:
 
 - `cnh (str | None)`: CNH string with 11 digits (symbols will be ignored).
 
-**Returns:**
+Returns:
 
 - `bool`: `True` if the check digits are consistent, `False` otherwise.
 
-**Example:**
+Example:
 
 ```python
 >>> from brutils import is_valid_cnh
@@ -1368,15 +1368,15 @@ False
 
 Removes any character that is not a digit from a CNH.
 
-**Args:**
+Args:
 
 * `cnh (str | None)`: String containing the CNH with or without symbols.
 
-**Returns:**
+Returns:
 
 * `str | None`: The CNH containing only digits, or `None` if the input is invalid.
 
-**Example:**
+Example:
 
 ```python
 >>> from brutils import remove_symbols_cnh

--- a/README_EN.md
+++ b/README_EN.md
@@ -1325,42 +1325,37 @@ None
 
 ### is_valid_cnh
 
-Returns whether the check digits of the provided CNH match its base number.
+Returns whether the provided CNH meets the basic formatting rules.
 
 Notes:
 
-- This function does not query official databases (BINCO/SENATRAN). It only performs the arithmetic validation of the check digits (pre-validation).
+- This function does not query official databases (Detran/Senatran).
+- It does not perform check digit calculations.
 - Rejects sequences where all digits are the same.
+- Ignores common symbols (dots, hyphens, spaces).
 
-Rules (modulo 11 – common practice in Brazilian documents):
+Arguments:
 
-1) Consider the first 9 digits as the base.  
-2) First check digit (10th digit):  
-   `sum1 = Σ base[i] * decreasing weight (9..1)`  
-   `dv1 = sum1 % 11; if dv1 >= 10 → dv1 = 0`  
-3) Second check digit (11th digit):  
-   `sum2 = Σ base[i] * increasing weight (1..9) + dv1 * 2`  
-   `dv2 = sum2 % 11; if dv2 >= 10 → dv2 = 0`
-
-Args:
-
-- `cnh (str | None)`: CNH string with 11 digits (symbols will be ignored).
+- `cnh (str | None)`: CNH string (with or without symbols).
 
 Returns:
 
-- `bool`: `True` if the check digits are consistent, `False` otherwise.
+- `bool`: `True` if it has 11 valid numeric digits and is not a repeated sequence, `False` otherwise.
 
 Example:
 
 ```python
->>> from brutils import is_valid_cnh
->>> is_valid_cnh("270.694.311-77")
+>>> from brutils.cnh import is_valid_cnh
+
+>>> is_valid_cnh("02926434554")
 True
->>> is_valid_cnh("27069431170")  # changed check digit
+>>> is_valid_cnh("11111111111")
 False
->>> is_valid_cnh("11111111111")  # repeated digits
+>>> is_valid_cnh("029.264.345-54")
+True
+>>> is_valid_cnh("12345678")
 False
->>> is_valid_cnh("123")          # wrong length
+>>> is_valid_cnh(None)
 False
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -99,6 +99,9 @@ False
 - [Monetary](#monetary)
   - [format_currency](#format_currency)
   - [convert\_real\_to\_text](#convert_real_to_text)
+- [CNH](#cnh)
+  - [is\_valid\_cnh](#is_valid_cnh)
+  - [remove\_symbols\_cnh](#remove_symbols_cnh)
 
 ## CPF
 
@@ -1315,6 +1318,73 @@ Example:
 >>> convert_real_to_text(-50.25)
 'Menos cinquenta reais e vinte e cinco centavos'
 >>> convert_real_to_text("invalid")
+None
+```
+
+## CNH
+
+### is_valid_cnh
+
+Returns whether the check digits of the provided CNH match its base number.
+
+Notes:
+
+- This function does not query official databases (BINCO/SENATRAN). It only performs the arithmetic validation of the check digits (pre-validation).
+- Rejects sequences where all digits are the same.
+
+Rules (modulo 11 – common practice in Brazilian documents):
+
+1) Consider the first 9 digits as the base.  
+2) First check digit (10th digit):  
+   `sum1 = Σ base[i] * decreasing weight (9..1)`  
+   `dv1 = sum1 % 11; if dv1 >= 10 → dv1 = 0`  
+3) Second check digit (11th digit):  
+   `sum2 = Σ base[i] * increasing weight (1..9) + dv1 * 2`  
+   `dv2 = sum2 % 11; if dv2 >= 10 → dv2 = 0`
+
+**Args:**
+
+- `cnh (str | None)`: CNH string with 11 digits (symbols will be ignored).
+
+**Returns:**
+
+- `bool`: `True` if the check digits are consistent, `False` otherwise.
+
+**Example:**
+
+```python
+>>> from brutils import is_valid_cnh
+>>> is_valid_cnh("270.694.311-77")
+True
+>>> is_valid_cnh("27069431170")  # changed check digit
+False
+>>> is_valid_cnh("11111111111")  # repeated digits
+False
+>>> is_valid_cnh("123")          # wrong length
+False
+```
+
+### remove_symbols_cnh
+
+Removes any character that is not a digit from a CNH.
+
+**Args:**
+
+* `cnh (str | None)`: String containing the CNH with or without symbols.
+
+**Returns:**
+
+* `str | None`: The CNH containing only digits, or `None` if the input is invalid.
+
+**Example:**
+
+```python
+>>> from brutils import remove_symbols_cnh
+>>> remove_symbols_cnh("270.694.311-77")
+'27069431177'
+>>> remove_symbols_cnh(None)
+None
+>>> remove_symbols_cnh(12345678901)  # not a string
 None
 ```
 

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -8,6 +8,9 @@ from brutils.cep import generate as generate_cep
 from brutils.cep import is_valid as is_valid_cep
 from brutils.cep import remove_symbols as remove_symbols_cep
 
+# CNH Imports
+from brutils.cnh import is_valid_cnh, remove_symbols_cnh
+
 # CNPJ Imports
 from brutils.cnpj import format_cnpj
 from brutils.cnpj import generate as generate_cnpj
@@ -131,4 +134,7 @@ __all__ = [
     # Currency
     "format_currency",
     "convert_real_to_text",
+    # CNH
+    "is_valid_cnh",
+    "remove_symbols_cnh",
 ]

--- a/brutils/cnh.py
+++ b/brutils/cnh.py
@@ -25,53 +25,30 @@ def remove_symbols_cnh(cnh: str | None) -> str | None:
 
 def is_valid_cnh(cnh: str | None) -> bool:
     """
-    Returns whether the check digits of the provided CNH match its base number.
+    Check if a CNH number is valid by format rules:
+    - Must be a non-empty string with exactly 11 digits.
+    - Cannot be a sequence of the same digit (e.g., '00000000', '11111111').
 
-    Notes:
-    - This function does not query official databases (BINCO/SENATRAN). It only performs
-    the arithmetic validation of the check digits (pre-validation).
-    - Rejects sequences where all digits are the same.
-
-    Rules (modulo 11 – common practice in Brazilian documents):
-    1) Consider the first 9 digits as the base.
-    2) First check digit (10th digit):
-        sum1 = Σ base[i] * decreasing weight (9..1)
-        dv1 = sum1 % 11; if dv1 >= 10 → dv1 = 0
-    3) Second check digit (11th digit):
-        sum2 = Σ base[i] * increasing weight (1..9) + dv1 * 2
-        dv2 = sum2 % 11; if dv2 >= 10 → dv2 = 0
+    Note:
+        This does NOT query bases oficiais (Detran/Senatran) nem valida dígitos verificadores,
+        serve apenas como pré-validação de formato e repetição.
 
     Args:
-        cnh (str | None): CNH string with 11 digits (symbols will be ignored).
+        cnh (str | None): CNH string (symbols will be ignored).
 
     Returns:
-        bool: True if the check digits are consistent, False otherwise.
+        bool: True if CNH has 11 numeric digits and is not all the same digit.
     """
-    digits_only = remove_symbols_cnh(cnh)
-    if not digits_only or len(digits_only) != 11 or not digits_only.isdigit():
+    if not cnh:
         return False
 
-    # reject sequences like 000..., 111..., etc.
+    digits_only = "".join(ch for ch in cnh if ch.isdigit())
+
+    if len(digits_only) != 11:
+        return False
+
+    # Reject sequences as "00000000000", "11111111111", etc.
     if digits_only == digits_only[0] * 11:
         return False
 
-    nums = [int(ch) for ch in digits_only]
-
-    # base: first 9 digits
-    base = nums[:9]
-    dv_expected_1 = nums[9]
-    dv_expected_2 = nums[10]
-
-    # first check digit: weights 9..1
-    soma1 = sum(d * w for d, w in zip(base, range(9, 0, -1)))
-    dv1 = soma1 % 11
-    if dv1 >= 10:
-        dv1 = 0
-
-    # second check digit: weights 1..9 + dv1*2
-    soma2 = sum(d * w for d, w in zip(base, range(1, 10))) + dv1 * 2
-    dv2 = soma2 % 11
-    if dv2 >= 10:
-        dv2 = 0
-
-    return dv1 == dv_expected_1 and dv2 == dv_expected_2
+    return True

--- a/brutils/cnh.py
+++ b/brutils/cnh.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import re
+from typing import Final
+
+__all__ = ["is_valid_cnh", "remove_symbols_cnh"]
+
+_DIGITS_RE: Final = re.compile(r"\D+")
+
+
+def remove_symbols_cnh(cnh: str | None) -> str | None:
+    """
+    Removes any character that is not a digit from a CNH.
+
+    Args:
+        cnh (str | None): String containing the CNH with or without symbols.
+
+    Returns:
+        str | None: The CNH containing only digits, or None if the input is invalid.
+    """
+    if not isinstance(cnh, str):
+        return None
+    return _DIGITS_RE.sub("", cnh)
+
+
+def is_valid_cnh(cnh: str | None) -> bool:
+    """
+    Returns whether the check digits of the provided CNH match its base number.
+
+    Notes:
+    - This function does not query official databases (BINCO/SENATRAN). It only performs
+    the arithmetic validation of the check digits (pre-validation).
+    - Rejects sequences where all digits are the same.
+
+    Rules (modulo 11 – common practice in Brazilian documents):
+    1) Consider the first 9 digits as the base.
+    2) First check digit (10th digit):
+        sum1 = Σ base[i] * decreasing weight (9..1)
+        dv1 = sum1 % 11; if dv1 >= 10 → dv1 = 0
+    3) Second check digit (11th digit):
+        sum2 = Σ base[i] * increasing weight (1..9) + dv1 * 2
+        dv2 = sum2 % 11; if dv2 >= 10 → dv2 = 0
+
+    Args:
+        cnh (str | None): CNH string with 11 digits (symbols will be ignored).
+
+    Returns:
+        bool: True if the check digits are consistent, False otherwise.
+    """
+    digits_only = remove_symbols_cnh(cnh)
+    if not digits_only or len(digits_only) != 11 or not digits_only.isdigit():
+        return False
+
+    # reject sequences like 000..., 111..., etc.
+    if digits_only == digits_only[0] * 11:
+        return False
+
+    nums = [int(ch) for ch in digits_only]
+
+    # base: first 9 digits
+    base = nums[:9]
+    dv_expected_1 = nums[9]
+    dv_expected_2 = nums[10]
+
+    # first check digit: weights 9..1
+    soma1 = sum(d * w for d, w in zip(base, range(9, 0, -1)))
+    dv1 = soma1 % 11
+    if dv1 >= 10:
+        dv1 = 0
+
+    # second check digit: weights 1..9 + dv1*2
+    soma2 = sum(d * w for d, w in zip(base, range(1, 10))) + dv1 * 2
+    dv2 = soma2 % 11
+    if dv2 >= 10:
+        dv2 = 0
+
+    return dv1 == dv_expected_1 and dv2 == dv_expected_2

--- a/tests/test_cnh.py
+++ b/tests/test_cnh.py
@@ -1,0 +1,82 @@
+from unittest import TestCase, main
+
+from brutils.cnh import is_valid_cnh, remove_symbols_cnh
+
+
+class TestCNH(TestCase):
+    def test_remove_symbols_cnh_ok(self):
+        cases = [
+            ("123.456.789-00", "12345678900"),
+            ("  053.180.594-10  ", "05318059410"),
+            ("41010881538", "41010881538"),
+            ("", ""),  # empty string remains empty
+            ("abc", ""),  # no digits → empty string
+            ("--93-825.480-731--", "93825480731"),
+        ]
+        for raw, expected in cases:
+            with self.subTest(raw=raw):
+                self.assertEqual(remove_symbols_cnh(raw), expected)
+
+    def test_remove_symbols_cnh_invalid_types(self):
+        invalid_inputs = [None, 123, 12.3, object()]
+        for invalid in invalid_inputs:
+            with self.subTest(invalid=invalid):
+                self.assertIsNone(remove_symbols_cnh(invalid))
+
+    def test_is_valid_cnh_true_digits_only(self):
+        valid_cases = [
+            "05318059410",
+            "41010881538",
+            "55541187371",
+            "89134024277",
+            "93825480731",
+        ]
+        for cnh in valid_cases:
+            with self.subTest(cnh=cnh):
+                self.assertTrue(is_valid_cnh(cnh))
+
+    def test_is_valid_cnh_true_with_symbols(self):
+        formatted_cases = [
+            "053.180.594-10",
+            "410.108.815-38",
+            "555.411.873-71",
+            "891.340.242-77",
+            "938.254.807-31",
+        ]
+        for cnh in formatted_cases:
+            with self.subTest(cnh=cnh):
+                self.assertTrue(is_valid_cnh(cnh))
+
+    def test_is_valid_cnh_false(self):
+        invalid_cases = [
+            # repeated digit sequences
+            "00000000000",
+            "11111111111",
+            "22222222222",
+            # invalid length
+            "1234567890",  # 10 digits
+            "123456789012",  # 12 digits
+            # non-numeric after cleaning
+            "abc",
+            "",
+            # wrong check digit
+            "05318059411",  # last digit changed
+            "41010881530",  # last digit changed
+        ]
+        for cnh in invalid_cases:
+            with self.subTest(cnh=cnh):
+                self.assertFalse(is_valid_cnh(cnh))
+
+    def test_is_valid_cnh_none_input(self):
+        self.assertFalse(is_valid_cnh(None))
+
+    def test_pipeline_remove_then_validate(self):
+        """Full pipeline: remove symbols then validate."""
+        raw = " 053.180.594-10 "
+        cleaned = remove_symbols_cnh(raw)
+        self.assertEqual(cleaned, "05318059410")
+        self.assertTrue(is_valid_cnh(cleaned))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cnh.py
+++ b/tests/test_cnh.py
@@ -1,10 +1,10 @@
 # tests/test_cnh.py
 import unittest
+
 from brutils.cnh import is_valid_cnh, remove_symbols_cnh
 
 
 class TestIsValidCnhRobust(unittest.TestCase):
-    
     # Valid inputs (11 digits, not all equal)
     def test_valid_plain_digits(self):
         for cnh in ["02926434554", "12345678901", "98765432109", "00000000001"]:
@@ -37,19 +37,18 @@ class TestIsValidCnhRobust(unittest.TestCase):
 
     def test_valid_with_unicode_spaces(self):
         # Non-breaking space (U+00A0), zero-width space (U+200B) etc. are ignored
-        cnh = "123" + "\u00A0" + "456" + "\u200B" + "789" + "\u00A0" + "01"
+        cnh = "123" + "\u00a0" + "456" + "\u200b" + "789" + "\u00a0" + "01"
         self.assertTrue(is_valid_cnh(cnh))
 
-    
     # Invalid: not exactly 11 digits after cleaning
     def test_invalid_length(self):
         cases = [
-            "",                # empty
-            "12345678",        # 8 digits
-            "1234567890",      # 10 digits
-            "123456789012",    # 12 digits
-            ".....-----",      # only symbols -> 0 digits
-            "abc",             # only letters -> 0 digits
+            "",  # empty
+            "12345678",  # 8 digits
+            "1234567890",  # 10 digits
+            "123456789012",  # 12 digits
+            ".....-----",  # only symbols -> 0 digits
+            "abc",  # only letters -> 0 digits
         ]
         for cnh in cases:
             with self.subTest(cnh=cnh):
@@ -58,28 +57,26 @@ class TestIsValidCnhRobust(unittest.TestCase):
     def test_invalid_many_digits_mixed_noise(self):
         # After stripping, > 11 digits → invalid
         cases = [
-            "12345678901" + "23",            # 13 digits
-            "id: 02926434554 and 999",       # 14 digits total
-            "111222333444555",               # 15 digits
+            "12345678901" + "23",  # 13 digits
+            "id: 02926434554 and 999",  # 14 digits total
+            "111222333444555",  # 15 digits
         ]
         for cnh in cases:
             with self.subTest(cnh=cnh):
                 self.assertFalse(is_valid_cnh(cnh))
 
-    
     # Invalid: all digits equal
     def test_invalid_all_digits_equal(self):
         cases = [
             "00000000000",
             "11111111111",
             "99999999999",
-            "000.000.000-00",   # formatted, but all equal after cleaning
+            "000.000.000-00",  # formatted, but all equal after cleaning
         ]
         for cnh in cases:
             with self.subTest(cnh=cnh):
                 self.assertFalse(is_valid_cnh(cnh))
 
-    
     # Whitespace / control chars / line breaks
     def test_whitespace_and_control_chars(self):
         cases = [
@@ -90,12 +87,10 @@ class TestIsValidCnhRobust(unittest.TestCase):
             with self.subTest(cnh=cnh):
                 self.assertTrue(is_valid_cnh(cnh))
 
-    
     # None and non-string behavior
     def test_none_input(self):
         self.assertFalse(is_valid_cnh(None))
 
-    
     # Pipeline with remove_symbols_cnh
     def test_pipeline_remove_symbols_then_validate(self):
         raw = " 029.264.345-54 "
@@ -103,13 +98,14 @@ class TestIsValidCnhRobust(unittest.TestCase):
         self.assertEqual(cleaned, "02926434554")
         self.assertTrue(is_valid_cnh(cleaned))
 
-    
     # Edge cases around leading zeros and near-repetition
     def test_leading_zeros_not_all_equal(self):
         self.assertTrue(is_valid_cnh("00000000009"))  # 10 zeros + 9 (valid)
 
     def test_repetition_with_one_change_is_valid(self):
-        self.assertTrue(is_valid_cnh("11111111112"))  # mostly equal, but not all
+        self.assertTrue(
+            is_valid_cnh("11111111112")
+        )  # mostly equal, but not all
 
 
 if __name__ == "__main__":

--- a/tests/test_cnh.py
+++ b/tests/test_cnh.py
@@ -1,82 +1,116 @@
-from unittest import TestCase, main
-
+# tests/test_cnh.py
+import unittest
 from brutils.cnh import is_valid_cnh, remove_symbols_cnh
 
 
-class TestCNH(TestCase):
-    def test_remove_symbols_cnh_ok(self):
+class TestIsValidCnhRobust(unittest.TestCase):
+    
+    # Valid inputs (11 digits, not all equal)
+    def test_valid_plain_digits(self):
+        for cnh in ["02926434554", "12345678901", "98765432109", "00000000001"]:
+            with self.subTest(cnh=cnh):
+                self.assertTrue(is_valid_cnh(cnh))
+
+    def test_valid_with_common_formatting(self):
         cases = [
-            ("123.456.789-00", "12345678900"),
-            ("  053.180.594-10  ", "05318059410"),
-            ("41010881538", "41010881538"),
-            ("", ""),  # empty string remains empty
-            ("abc", ""),  # no digits → empty string
-            ("--93-825.480-731--", "93825480731"),
+            "029.264.345-54",
+            "  123.456.789-01  ",
+            "\n987.654.321-09\t",
+            "000.000.000-01",
+            "123-456-789-01",
+            "123 456 789 01",
         ]
-        for raw, expected in cases:
-            with self.subTest(raw=raw):
-                self.assertEqual(remove_symbols_cnh(raw), expected)
-
-    def test_remove_symbols_cnh_invalid_types(self):
-        invalid_inputs = [None, 123, 12.3, object()]
-        for invalid in invalid_inputs:
-            with self.subTest(invalid=invalid):
-                self.assertIsNone(remove_symbols_cnh(invalid))
-
-    def test_is_valid_cnh_true_digits_only(self):
-        valid_cases = [
-            "05318059410",
-            "41010881538",
-            "55541187371",
-            "89134024277",
-            "93825480731",
-        ]
-        for cnh in valid_cases:
+        for cnh in cases:
             with self.subTest(cnh=cnh):
                 self.assertTrue(is_valid_cnh(cnh))
 
-    def test_is_valid_cnh_true_with_symbols(self):
-        formatted_cases = [
-            "053.180.594-10",
-            "410.108.815-38",
-            "555.411.873-71",
-            "891.340.242-77",
-            "938.254.807-31",
+    def test_valid_with_letters_and_symbols_ignored(self):
+        # Non-digits are ignored: letters/symbols are stripped; still 11 digits total
+        cases = [
+            "A12B345C678D90E1",
+            "XX029YY264ZZ345--54",
+            "id(987)key[654]{321}<09>",
         ]
-        for cnh in formatted_cases:
+        for cnh in cases:
             with self.subTest(cnh=cnh):
                 self.assertTrue(is_valid_cnh(cnh))
 
-    def test_is_valid_cnh_false(self):
-        invalid_cases = [
-            # repeated digit sequences
-            "00000000000",
-            "11111111111",
-            "22222222222",
-            # invalid length
-            "1234567890",  # 10 digits
-            "123456789012",  # 12 digits
-            # non-numeric after cleaning
-            "abc",
-            "",
-            # wrong check digit
-            "05318059411",  # last digit changed
-            "41010881530",  # last digit changed
+    def test_valid_with_unicode_spaces(self):
+        # Non-breaking space (U+00A0), zero-width space (U+200B) etc. are ignored
+        cnh = "123" + "\u00A0" + "456" + "\u200B" + "789" + "\u00A0" + "01"
+        self.assertTrue(is_valid_cnh(cnh))
+
+    
+    # Invalid: not exactly 11 digits after cleaning
+    def test_invalid_length(self):
+        cases = [
+            "",                # empty
+            "12345678",        # 8 digits
+            "1234567890",      # 10 digits
+            "123456789012",    # 12 digits
+            ".....-----",      # only symbols -> 0 digits
+            "abc",             # only letters -> 0 digits
         ]
-        for cnh in invalid_cases:
+        for cnh in cases:
             with self.subTest(cnh=cnh):
                 self.assertFalse(is_valid_cnh(cnh))
 
-    def test_is_valid_cnh_none_input(self):
+    def test_invalid_many_digits_mixed_noise(self):
+        # After stripping, > 11 digits → invalid
+        cases = [
+            "12345678901" + "23",            # 13 digits
+            "id: 02926434554 and 999",       # 14 digits total
+            "111222333444555",               # 15 digits
+        ]
+        for cnh in cases:
+            with self.subTest(cnh=cnh):
+                self.assertFalse(is_valid_cnh(cnh))
+
+    
+    # Invalid: all digits equal
+    def test_invalid_all_digits_equal(self):
+        cases = [
+            "00000000000",
+            "11111111111",
+            "99999999999",
+            "000.000.000-00",   # formatted, but all equal after cleaning
+        ]
+        for cnh in cases:
+            with self.subTest(cnh=cnh):
+                self.assertFalse(is_valid_cnh(cnh))
+
+    
+    # Whitespace / control chars / line breaks
+    def test_whitespace_and_control_chars(self):
+        cases = [
+            " \t\n12345678901\r\n",
+            "\f123.456.789-01\v",
+        ]
+        for cnh in cases:
+            with self.subTest(cnh=cnh):
+                self.assertTrue(is_valid_cnh(cnh))
+
+    
+    # None and non-string behavior
+    def test_none_input(self):
         self.assertFalse(is_valid_cnh(None))
 
-    def test_pipeline_remove_then_validate(self):
-        """Full pipeline: remove symbols then validate."""
-        raw = " 053.180.594-10 "
-        cleaned = remove_symbols_cnh(raw)
-        self.assertEqual(cleaned, "05318059410")
+    
+    # Pipeline with remove_symbols_cnh
+    def test_pipeline_remove_symbols_then_validate(self):
+        raw = " 029.264.345-54 "
+        cleaned = remove_symbols_cnh(raw)  # should be "02926434554"
+        self.assertEqual(cleaned, "02926434554")
         self.assertTrue(is_valid_cnh(cleaned))
+
+    
+    # Edge cases around leading zeros and near-repetition
+    def test_leading_zeros_not_all_equal(self):
+        self.assertTrue(is_valid_cnh("00000000009"))  # 10 zeros + 9 (valid)
+
+    def test_repetition_with_one_change_is_valid(self):
+        self.assertTrue(is_valid_cnh("11111111112"))  # mostly equal, but not all
 
 
 if __name__ == "__main__":
-    main()
+    unittest.main()


### PR DESCRIPTION
## Descrição
Adiciona duas funções ao módulo `brutils.cnh`:

* `remove_symbols_cnh`: remove caracteres não numéricos.
* `is_valid_cnh`: valida CNH (11 dígitos), aceitando entradas com símbolos e rejeitando sequências repetidas.

Inclui suíte de testes em unittest cobrindo casos válidos, inválidos, formatados e pipeline limpeza→validação.

## Mudanças Propostas
* **Novo**: `brutils/cnh.py` com `remove_symbols_cnh` e `is_valid_cnh`.
* **Novo**: `tests/test_cnh.py` (unittest).
* **Docs**: exemplos de uso nas docstrings.

## Checklist de Revisão
- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.

## Issue Relacionada
Closes [#578](https://github.com/brazilian-utils/brutils-python/issues/578)
