### PR TITLE
feat(ibge): adiciona utilitário convert_name_to_uf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Utilitário `convert_name_to_uf`
+
 ## [2.3.0] - 2025-10-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ False
 - [IBGE](#ibge)
   - [convert_code_to_uf](#convert_code_to_uf)
   - [convert_uf_to_name](#convert_uf_to_name)
+  - [convert_name_to_uf](#convert_name_to_uf)
   - [get_code_by_municipality_name](#get_code_by_municipality_name)
   - [get\_municipality\_by\_code](#get_municipality_by_code)
 - [Feriados](#feriados)
@@ -1217,6 +1218,33 @@ Exemplo:
 'São Paulo'
 >>> convert_uf_to_name('rj')
 'Rio de Janeiro'
+```
+
+### convert_name_to_uf
+Converte o nome completo de um estado brasileiro para seu código UF.
+
+Esta função recebe o nome completo de um estado brasileiro e retorna o código UF de duas letras correspondente. A comparação ignora maiúsculas/minúsculas e acentos.
+
+Argumentos:
+  * state_name (str): O nome completo do estado (por exemplo, 'São Paulo', 'sao paulo').
+
+Retorna:
+  * str | None: O código UF se encontrado, ou None se o nome do estado for inválido.
+
+Exemplo:
+
+```python
+>>> from brutils.ibge.uf import convert_name_to_uf
+>>> convert_name_to_uf('São Paulo')
+'SP'
+>>> convert_name_to_uf('sao paulo')
+'SP'
+>>> convert_name_to_uf('Rio de Janeiro')
+'RJ'
+>>> convert_name_to_uf('rio de janeiro')
+'RJ'
+>>> convert_name_to_uf('Estado Inválido')
+>>>
 ```
 
 ## Feriados

--- a/README_EN.md
+++ b/README_EN.md
@@ -91,9 +91,10 @@ False
   - [generate_voter_id](#generate_voter_id)
 - [IBGE](#ibge)
   - [convert_code_to_uf](#convert_code_to_uf)
+  - [convert_uf_to_name](#convert_uf_to_name)
+  - [convert_name_to_uf](#convert_name_to_uf)
   - [get_code_by_municipality_name](#get_code_by_municipality_name)
   - [get\_municipality\_by\_code](#get_municipality_by_code)
-  - [convert_uf_to_name](#convert_uf_to_name)
 - [Holidays](#holidays)
   - [is_holiday](#is_holiday)
 - [Monetary](#monetary)
@@ -1220,6 +1221,33 @@ Example:
 'São Paulo'
 >>> convert_uf_to_name('rj')
 'Rio de Janeiro'
+```
+
+### convert_name_to_uf
+Converts a Brazilian state name to its UF code.
+
+This function takes the full name of a Brazilian state and returns its corresponding two-letter UF code. The comparison is case-insensitive and ignores accents.
+
+Args:
+  * state_name (str): The full name of the state (e.g., 'São Paulo', 'sao paulo').
+
+Returns:
+  * str | None: The UF code if found, or None if the state name is invalid.
+
+Example:
+
+```python
+>>> from brutils.ibge.uf import convert_name_to_uf
+>>> convert_name_to_uf('São Paulo')
+'SP'
+>>> convert_name_to_uf('sao paulo')
+'SP'
+>>> convert_name_to_uf('Rio de Janeiro')
+'RJ'
+>>> convert_name_to_uf('rio de janeiro')
+'RJ'
+>>> convert_name_to_uf('Invalid State')
+>>>
 ```
 
 ## Holidays

--- a/brutils/__init__.py
+++ b/brutils/__init__.py
@@ -34,7 +34,11 @@ from brutils.ibge.municipality import (
     get_code_by_municipality_name,
     get_municipality_by_code,
 )
-from brutils.ibge.uf import convert_code_to_uf, convert_uf_to_name
+from brutils.ibge.uf import (
+    convert_code_to_uf,
+    convert_name_to_uf,
+    convert_uf_to_name,
+)
 
 # Legal Process Imports
 from brutils.legal_process import format_legal_process
@@ -122,6 +126,7 @@ __all__ = [
     "is_valid_voter_id",
     # IBGE
     "convert_code_to_uf",
+    "convert_name_to_uf",
     "convert_uf_to_name",
     "get_code_by_municipality_name",
     "get_municipality_by_code",

--- a/brutils/ibge/uf.py
+++ b/brutils/ibge/uf.py
@@ -1,3 +1,5 @@
+import unicodedata
+
 from brutils.data.enums.uf import UF, UF_CODE
 
 
@@ -59,3 +61,60 @@ def convert_uf_to_name(uf: str) -> str | None:
     result = UF[federal_unit].value
 
     return result
+
+
+def _normalize_text(text: str) -> str:
+    """
+    Normalize text by removing accents and normalizing whitespace.
+
+    Args:
+        text (str): The text to normalize.
+
+    Returns:
+        str: The normalized text in uppercase.
+    """
+    nfd = unicodedata.normalize("NFD", text)
+    without_accents = "".join(
+        char for char in nfd if unicodedata.category(char) != "Mn"
+    )
+
+    normalized_spaces = " ".join(without_accents.split())
+    return normalized_spaces.upper()
+
+
+def convert_name_to_uf(state_name: str) -> str | None:
+    """
+    Convert a Brazilian state name to its UF code.
+
+    This function takes the full name of a Brazilian state and returns its
+    corresponding two-letter UF code. The comparison is case-insensitive and
+    ignores accents.
+
+    Args:
+        state_name (str): The full name of the state (e.g., 'São Paulo', 'sao paulo').
+
+    Returns:
+        str | None: The UF code if found, or None if the state name is invalid.
+
+    Examples:
+        >>> convert_name_to_uf('São Paulo')
+        'SP'
+        >>> convert_name_to_uf('sao paulo')
+        'SP'
+        >>> convert_name_to_uf('Rio de Janeiro')
+        'RJ'
+        >>> convert_name_to_uf('rio de janeiro')
+        'RJ'
+        >>> convert_name_to_uf('Estado Inválido')
+        >>>
+    """
+    if not state_name or not isinstance(state_name, str):
+        return None
+
+    normalized_input = _normalize_text(state_name.strip())
+
+    for uf in UF:
+        if _normalize_text(uf.value) == normalized_input:
+            return uf.name
+
+    return None

--- a/tests/ibge/test_uf.py
+++ b/tests/ibge/test_uf.py
@@ -1,31 +1,158 @@
 from unittest import TestCase
 
-from brutils.ibge.uf import convert_code_to_uf, convert_uf_to_name
+from brutils.ibge.uf import (
+    convert_code_to_uf,
+    convert_name_to_uf,
+    convert_uf_to_name,
+)
 
 
 class TestUF(TestCase):
-    def test_convert_code_to_uf(self):
-        # Testes para códigos válidos
-        self.assertEqual(convert_code_to_uf("12"), "AC")
-        self.assertEqual(convert_code_to_uf("33"), "RJ")
-        self.assertEqual(convert_code_to_uf("31"), "MG")
-        self.assertEqual(convert_code_to_uf("52"), "GO")
+    def test_convert_code_to_uf_valid(self):
+        test_cases = [
+            ("12", "AC"),
+            ("27", "AL"),
+            ("16", "AP"),
+            ("13", "AM"),
+            ("29", "BA"),
+            ("23", "CE"),
+            ("53", "DF"),
+            ("32", "ES"),
+            ("52", "GO"),
+            ("21", "MA"),
+            ("51", "MT"),
+            ("50", "MS"),
+            ("31", "MG"),
+            ("15", "PA"),
+            ("25", "PB"),
+            ("41", "PR"),
+            ("26", "PE"),
+            ("22", "PI"),
+            ("33", "RJ"),
+            ("24", "RN"),
+            ("43", "RS"),
+            ("11", "RO"),
+            ("14", "RR"),
+            ("42", "SC"),
+            ("35", "SP"),
+            ("28", "SE"),
+            ("17", "TO"),
+        ]
+        for code, expected_uf in test_cases:
+            with self.subTest(code=code):
+                self.assertEqual(convert_code_to_uf(code), expected_uf)
 
-        # Testes para códigos inválidos
-        self.assertIsNone(convert_code_to_uf("99"))
-        self.assertIsNone(convert_code_to_uf("00"))
-        self.assertIsNone(convert_code_to_uf(""))
-        self.assertIsNone(convert_code_to_uf("AB"))
+    def test_convert_code_to_uf_invalid(self):
+        invalid_codes = ["99", "00", "", "AB", "1", "123"]
+        for invalid_code in invalid_codes:
+            with self.subTest(code=invalid_code):
+                self.assertIsNone(convert_code_to_uf(invalid_code))
 
-    def test_convert_uf_to_name(self):
-        # Testes para códigos válidos
-        self.assertEqual(convert_uf_to_name("SP"), "São Paulo")
-        self.assertEqual(convert_uf_to_name("RJ"), "Rio de Janeiro")
-        self.assertEqual(convert_uf_to_name("MG"), "Minas Gerais")
-        self.assertEqual(convert_uf_to_name("DF"), "Distrito Federal")
-        self.assertEqual(convert_uf_to_name("df"), "Distrito Federal")
+    def test_convert_uf_to_name_valid(self):
+        test_cases = [
+            ("SP", "São Paulo"),
+            ("RJ", "Rio de Janeiro"),
+            ("MG", "Minas Gerais"),
+            ("DF", "Distrito Federal"),
+            ("BA", "Bahia"),
+            ("RS", "Rio Grande do Sul"),
+        ]
+        for uf, expected_name in test_cases:
+            with self.subTest(uf=uf):
+                self.assertEqual(convert_uf_to_name(uf), expected_name)
 
-        # Testes para códigos inválidos
-        self.assertIsNone(convert_code_to_uf("XX"))
-        self.assertIsNone(convert_code_to_uf("XXX"))
-        self.assertIsNone(convert_code_to_uf(""))
+    def test_convert_uf_to_name_case_insensitive(self):
+        test_cases = [
+            ("sp", "São Paulo"),
+            ("df", "Distrito Federal"),
+            ("Rj", "Rio de Janeiro"),
+        ]
+        for uf, expected_name in test_cases:
+            with self.subTest(uf=uf):
+                self.assertEqual(convert_uf_to_name(uf), expected_name)
+
+    def test_convert_uf_to_name_invalid(self):
+        invalid_ufs = ["XX", "XXX", "", "A", "123", "  "]
+        for invalid_uf in invalid_ufs:
+            with self.subTest(uf=invalid_uf):
+                self.assertIsNone(convert_uf_to_name(invalid_uf))
+
+    def test_convert_name_to_uf_all_states(self):
+        test_cases = [
+            ("Acre", "AC"),
+            ("Alagoas", "AL"),
+            ("Amapá", "AP"),
+            ("Amazonas", "AM"),
+            ("Bahia", "BA"),
+            ("Ceará", "CE"),
+            ("Distrito Federal", "DF"),
+            ("Espírito Santo", "ES"),
+            ("Goiás", "GO"),
+            ("Maranhão", "MA"),
+            ("Mato Grosso", "MT"),
+            ("Mato Grosso do Sul", "MS"),
+            ("Minas Gerais", "MG"),
+            ("Pará", "PA"),
+            ("Paraíba", "PB"),
+            ("Paraná", "PR"),
+            ("Pernambuco", "PE"),
+            ("Piauí", "PI"),
+            ("Rio de Janeiro", "RJ"),
+            ("Rio Grande do Norte", "RN"),
+            ("Rio Grande do Sul", "RS"),
+            ("Rondônia", "RO"),
+            ("Roraima", "RR"),
+            ("Santa Catarina", "SC"),
+            ("São Paulo", "SP"),
+            ("Sergipe", "SE"),
+            ("Tocantins", "TO"),
+        ]
+        for state_name, expected_uf in test_cases:
+            with self.subTest(state_name=state_name):
+                self.assertEqual(convert_name_to_uf(state_name), expected_uf)
+
+    def test_convert_name_to_uf_normalization(self):
+        test_cases = [
+            ("sao paulo", "SP"),
+            ("SAO PAULO", "SP"),
+            ("SãO pAuLo", "SP"),
+            ("  Rio de Janeiro  ", "RJ"),
+            ("ceara", "CE"),
+            ("PARANÁ", "PR"),
+            ("parana", "PR"),
+        ]
+        for state_name, expected_uf in test_cases:
+            with self.subTest(state_name=state_name):
+                self.assertEqual(convert_name_to_uf(state_name), expected_uf)
+
+    def test_convert_name_to_uf_wrong_spacing(self):
+        test_cases = [
+            ("Sao  Paulo", "SP"),
+            ("Rio  de  Janeiro", "RJ"),
+            ("Mato   Grosso", "MT"),
+            ("Rio   Grande   do   Sul", "RS"),
+            ("Mato  Grosso  do  Sul", "MS"),
+            ("Espírito  Santo", "ES"),
+            ("Rio Grande  do Norte", "RN"),
+        ]
+        for state_name, expected_uf in test_cases:
+            with self.subTest(state_name=state_name):
+                self.assertEqual(convert_name_to_uf(state_name), expected_uf)
+
+    def test_convert_name_to_uf_invalid_input(self):
+        invalid_inputs = [
+            None,
+            "",
+            "   ",
+            "Estado Inválido",
+            "São Pauloo",
+            "Rio",
+            "Brasil",
+            "XYZ",
+            123,
+            [],
+            {},
+        ]
+        for invalid_input in invalid_inputs:
+            with self.subTest(input=repr(invalid_input)):
+                self.assertIsNone(convert_name_to_uf(invalid_input))


### PR DESCRIPTION
## Descrição

Este PR adiciona a função `convert_name_to_uf` ao módulo IBGE, que converte nomes completos de estados brasileiros em seus códigos UF correspondentes.

O módulo IBGE já oferece conversões de código IBGE para UF e de UF para nome do estado. No entanto, faltava a conversão inversa: dado o nome de um estado, obter seu código UF.

A função aceita variações na entrada, ignorando diferenças de acentuação e capitalização. Por exemplo, "São Paulo", "sao paulo" e "SAO PAULO" são todas convertidas corretamente para "SP".

## Mudanças Propostas

A nova função completa o conjunto de utilitários de conversão do módulo IBGE. A implementação inclui normalização de texto para tornar a função mais flexível e robusta ao lidar com diferentes formatos de entrada.

Os testes foram expandidos para cobrir todos os estados brasileiros e diversos cenários de uso, incluindo validação de entradas inválidas. A documentação foi atualizada em português e inglês com exemplos práticos de uso.

## Checklist de Revisão

- [x] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [x] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [x] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [x] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md).
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [x] Não há conflitos de mesclagem.

## Issue Relacionada

Closes #396