### PR TITLE
478

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+
+- Tratando CNPJ formato 2026 nos métodos do utilitário cnpj (https://github.com/brazilian-utils/python/issues/478)
+
 ## [2.3.0] - 2025-10-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Verifica se os dígitos de verificação do CNPJ (Cadastro Nacional da Pessoa
 Jurídica) fornecido correspondem ao seu número base. A entrada deve ser uma
 string de dígitos com o comprimento apropriado. Esta função não verifica a
 existência do CNPJ; ela só valida o formato da string.
+OBS.: Já está tratando CNPJs no novo formato (2026)
 
 Argumentos:
 
@@ -216,6 +217,8 @@ Exemplo:
 ```python
 >>> from brutils import is_valid_cnpj
 >>> is_valid_cnpj('03560714000142')
+True
+>>> is_valid_cnpj('12ABC34501DE')
 True
 >>> is_valid_cnpj('00111222000133')
 False
@@ -242,6 +245,8 @@ Exemplo:
 >>> from brutils import format_cnpj
 >>> format_cnpj("03560714000142")
 '03.560.714/0001-42'
+>>> format_cnpj("12ABC34501DE35")
+'12.ABC.345/01DE-35'
 >>> format_cnpj("98765432100100")
 None
 ```
@@ -277,6 +282,7 @@ opcional pode ser fornecido; o padrão é 1.
 Argumentos:
 
 - branch (int): Um número de filial opcional a ser incluído no CNPJ.
+- new_format (bool): Boolean para definir se o CNPJ será no novo formato (2026).
 
 Retorna:
 
@@ -288,6 +294,8 @@ Exemplo:
 >>> from brutils import generate_cnpj
 >>> generate_cnpj()
 '34665388000161'
+>>> generate_cnpj(new_format=True)
+'BDPDVE7250ZX31'
 >>> generate_cnpj(1234)
 "01745284123455"
 ```

--- a/README_EN.md
+++ b/README_EN.md
@@ -202,6 +202,7 @@ Returns whether or not the verifying checksum digits of the given CNPJ
 Input should be a digit string of proper length.
 This function does not verify the existence of the CNPJ; it only
 validates the format of the string.
+P.S.: It's already included the new CNPJ version (2026)
 
 Args:
 
@@ -217,6 +218,8 @@ Example:
 ```python
 >>> from brutils import is_valid_cnpj
 >>> is_valid_cnpj('03560714000142')
+True
+>>> is_valid_cnpj('12ABC34501DE')
 True
 >>> is_valid_cnpj('00111222000133')
 False
@@ -244,6 +247,8 @@ Example:
 >>> from brutils import format_cnpj
 >>> format_cnpj("03560714000142")
 '03.560.714/0001-42'
+>>> format_cnpj("12ABC34501DE35")
+'12.ABC.345/01DE-35'
 >>> format_cnpj("98765432100100")
 None
 ```
@@ -279,6 +284,7 @@ string. An optional branch number parameter can be given; it defaults to 1.
 Args:
 
 - branch (int): An optional branch number to be included in the CNPJ.
+- new_format (bool): Bool to use the new CNPJ version format (2026).
 
 Returns:
 
@@ -290,6 +296,8 @@ Example:
 >>> from brutils import generate_cnpj
 >>> generate_cnpj()
 '34665388000161'
+>>> generate_cnpj(new_format=True)
+'BDPDVE7250ZX31'
 >>> generate_cnpj(1234)
 "01745284123455"
 ```

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -3,11 +3,15 @@ from unittest.mock import patch
 
 from brutils.cnpj import (
     _checksum,
+    _checksum_alphanumeric,
     _hashdigit,
+    _hashdigit_alphanumeric,
+    ascii_value,
     display,
     format_cnpj,
     generate,
     is_valid,
+    is_alphanumeric_cnpj,
     remove_symbols,
     sieve,
     validate,
@@ -15,6 +19,10 @@ from brutils.cnpj import (
 
 
 class TestCNPJ(TestCase):
+    # -------------------------------------------------------------------------
+    # LEGACY TESTS (numeric CNPJ)
+    # -------------------------------------------------------------------------
+
     def test_sieve(self):
         self.assertEqual(sieve("00000000000"), "00000000000")
         self.assertEqual(sieve("12.345.678/0001-90"), "12345678000190")
@@ -25,11 +33,41 @@ class TestCNPJ(TestCase):
         )
         self.assertEqual(sieve("/...---.../"), "")
 
-    def test_display(self):
-        self.assertEqual(display("00000000000109"), "00.000.000/0001-09")
-        self.assertIsNone(display("00000000000000"))
-        self.assertIsNone(display("0000000000000"))
-        self.assertIsNone(display("0000000000000a"))
+    def test_display_numeric_valid(self):
+        # Traditional numeric CNPJ
+        self.assertEqual(display("12345678000195"), "12.345.678/0001-95")
+
+    def test_display_alphanumeric_valid(self):
+        # Alphanumeric CNPJ (valid from 2026)
+        formatted = display("12ABC34501DE35")
+        self.assertEqual(formatted, "12.ABC.345/01DE-35")
+
+    def test_display_invalid_cases(self):
+        # Too short
+        self.assertIsNone(display("1234567890123"))
+        # All same character
+        self.assertIsNone(display("AAAAAAAAAAAAAA"))
+        # Empty string
+        self.assertIsNone(display(""))
+
+    def test_format_cnpj_numeric_valid(self):
+        # Numeric CNPJ should format properly
+        self.assertEqual(format_cnpj("03560714000142"), "03.560.714/0001-42")
+
+    def test_format_cnpj_alphanumeric_valid(self):
+        # Alphanumeric CNPJ with computed DV
+        base = "12ABC34501DE"
+        dv = _checksum_alphanumeric(base)
+        valid_cnpj = base + dv
+        formatted = format_cnpj(valid_cnpj)
+        self.assertEqual(formatted, "12.ABC.345/01DE-" + dv)
+
+    def test_format_cnpj_invalid_returns_none(self):
+        # Invalid numeric
+        self.assertIsNone(format_cnpj("12345678000100"))
+        # Invalid alphanumeric (wrong DV)
+        self.assertIsNone(format_cnpj("12ABC34501DE99"))
+
 
     def test_validate(self):
         self.assertIs(validate("34665388000161"), True)
@@ -68,9 +106,10 @@ class TestCNPJ(TestCase):
         self.assertIs(is_valid("01838723000127"), True)
 
     def test_generate(self):
-        for _ in range(10_000):
-            self.assertIs(validate(generate()), True)
-            self.assertIsNotNone(display(generate()))
+        for _ in range(1000):
+            cnpj = generate()
+            self.assertTrue(validate(cnpj))
+            self.assertIsNotNone(display(cnpj))
 
     def test__hashdigit(self):
         self.assertEqual(_hashdigit("00000000000000", 13), 0)
@@ -81,6 +120,64 @@ class TestCNPJ(TestCase):
     def test__checksum(self):
         self.assertEqual(_checksum("00000000000000"), "00")
         self.assertEqual(_checksum("52513127000299"), "99")
+
+    # -------------------------------------------------------------------------
+    # NEW TESTS (alphanumeric CNPJ - 2026 format)
+    # -------------------------------------------------------------------------
+
+    def test_is_alphanumeric_cnpj(self):
+        self.assertTrue(is_alphanumeric_cnpj("12AB345C0001D5"))
+        self.assertFalse(is_alphanumeric_cnpj("12345678000195"))
+
+    def test_ascii_value_conversion(self):
+        # Digits: ASCII(0–9) → 48–57 → minus 48 → 0–9
+        self.assertEqual(ascii_value("0"), 0)
+        self.assertEqual(ascii_value("9"), 9)
+        # Letters: ASCII(A) = 65 → minus 48 → 17
+        self.assertEqual(ascii_value("A"), 17)
+        self.assertEqual(ascii_value("Z"), 42)
+        self.assertEqual(ascii_value("b"), 18)  # lowercase also works
+
+    def test_hashdigit_alphanumeric(self):
+        # Simple test to ensure deterministic checksum generation
+        result = _hashdigit_alphanumeric("12ABC34501DE", 13)
+        self.assertIsInstance(result, int)
+        self.assertTrue(0 <= result <= 9)
+
+    def test_checksum_alphanumeric(self):
+        # Ensure it returns exactly 2 digits as string
+        base = "12ABC34501DE"
+        dv = _checksum_alphanumeric(base)
+        self.assertEqual(len(dv), 2)
+        self.assertTrue(dv.isdigit())
+
+    def test_validate_cnpj_alphanumeric(self):
+        base = "12ABC34501DE"
+        dv = _checksum_alphanumeric(base)
+        valid_cnpj = base + dv
+
+        # Should be valid
+        self.assertTrue(validate(valid_cnpj))
+        self.assertTrue(is_valid(valid_cnpj))
+
+        # Invalid if DV altered
+        invalid_cnpj = valid_cnpj[:-1] + "9"
+        self.assertFalse(validate(invalid_cnpj))
+
+    def test_generate_alphanumeric(self):
+        # Generates and validates 100 random new-format CNPJs
+        for _ in range(200):
+            cnpj = generate(new_format=True)
+            self.assertEqual(len(cnpj), 14)
+            self.assertTrue(any(c.isalpha() for c in cnpj[:12]))
+            self.assertTrue(cnpj[-2:].isdigit())
+            self.assertTrue(is_valid(cnpj))
+
+    def test_generate_branch_numeric_still_valid(self):
+        # Backward compatible
+        cnpj = generate(branch=9999)
+        self.assertTrue(is_valid(cnpj))
+        self.assertFalse(any(c.isalpha() for c in cnpj))
 
 
 @patch("brutils.cnpj.sieve")


### PR DESCRIPTION
## Descrição
Resolve o formato novo de CNPJ que estará em vigor a partir de 2026 no utilitário 'cnpj'.

## Mudanças Propostas
- Utilitário cnpj agora pode tratar CNPJs do novo formato de CNPJ disponibilizado em: https://normasinternet2.receita.fazenda.gov.br/#/consulta/externa/141102


## Checklist de Revisão
- [X] Eu li o [Contributing.md](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md)
- [X] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [X] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [X] A [documentação](https://github.com/brazilian-utils/brutils-python/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [X] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/brazilian-utils/brutils-python/blob/main/README_EN.md). <!---Permitido uso de Google Tradutor/ChatGPT. -->
- [X] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [X] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [X] Todos os testes passam. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#testes)
- [X] O Pull Request foi testado localmente. [Instruções](https://github.com/brazilian-utils/brutils-python/blob/main/CONTRIBUTING.md#7-execute-o-brutils-localmente)
- [X] Não há conflitos de mesclagem.

## Comentários Adicionais (opcional)

## Issue Relacionada
https://github.com/brazilian-utils/python/issues/478

Closes #478 
