### PR TITLE
chore: release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-04-20
+
 ### Added
 
 - Utilitário `convert_name_to_uf` [#606](https://github.com/brazilian-utils/python/pull/606)
@@ -118,7 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `cnpj.display`
 - Utilitário `cnpj.validate`
 
-[Unreleased]: https://github.com/brazilian-utils/brutils-python/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/brazilian-utils/brutils-python/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.4.0
 [2.3.0]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.3.0
 [2.2.0]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.2.0
 [2.1.1]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "brutils"
-version = "2.3.0"
+version = "2.4.0"
 description = "Utils library for specific Brazilian businesses"
 authors = ["The Brazilian Utils Organization"]
 license = "MIT"


### PR DESCRIPTION
### Added

- Utilitário `convert_name_to_uf` [#606](https://github.com/brazilian-utils/python/pull/606)
- Utilitário `is_valid_legal_nature` [#653](https://github.com/brazilian-utils/python/pull/653)
- Utilitário `get_legal_nature_description` [#653](https://github.com/brazilian-utils/python/pull/653)
- Utilitário `list_all_legal_nature` [#653](https://github.com/brazilian-utils/python/pull/653)
- Utilitário `is_valid_cnh` [#651](https://github.com/brazilian-utils/brutils-python/pull/651)
- Utilitário `is_valid_renavam` [#652](https://github.com/brazilian-utils/brutils-python/pull/652)
- Utilitário `is_valid_passport` [#699](https://github.com/brazilian-utils/python/pull/699)
- Utilitário `generate_passport` [#699](https://github.com/brazilian-utils/python/pull/699)
- Utilitário `format_passport` [#699](https://github.com/brazilian-utils/python/pull/699)
- Utilitário `remove_symbols_passport` [#699](https://github.com/brazilian-utils/python/pull/699)

### Fixed

- Utilitário `brutils/cep.py` [#637](https://github.com/brazilian-utils/python/pull/637)
- Utilitário `legal_process` [#634](https://github.com/brazilian-utils/python/pull/634)
- Utilitário `voter_id` [#638](https://github.com/brazilian-utils/python/pull/638)

Closes #719 
