### PR TITLE
fix: keep all digits when formatting 13-digit SP/MG voter ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `format_voter_id` [#742](https://github.com/brazilian-utils/python/pull/742)
+
 ## [2.4.0] - 2026-04-20
 
 ### Added

--- a/brutils/voter_id.py
+++ b/brutils/voter_id.py
@@ -285,11 +285,24 @@ def format_voter_id(voter_id: str) -> str | None:
         '6908 4709 28 28'
         >>> format_voter_id("163204010922")
         '1632 0401 09 22'
+        >>> format_voter_id("3244567800167")
+        '32445 6780 01 67'
     """
 
     if not is_valid(voter_id):
         return None
 
+    # The sequential number has 8 digits, except for the SP and MG edge case,
+    # where it can have 9 digits (making the voter id 13 digits long). The
+    # federative union and verifying digits are always the last 4 digits.
+    sequential_number = voter_id[:-4]
+    federative_union = _get_federative_union(voter_id)
+    verifying_digits = _get_verifying_digits(voter_id)
+
+    split = len(sequential_number) - 4
     return "{} {} {} {}".format(
-        voter_id[:4], voter_id[4:8], voter_id[8:10], voter_id[10:12]
+        sequential_number[:split],
+        sequential_number[split:],
+        federative_union,
+        verifying_digits,
     )

--- a/tests/test_voter_id.py
+++ b/tests/test_voter_id.py
@@ -127,6 +127,16 @@ class TestIsValid(TestCase):
         self.assertIsNone(format_voter_id("000000000000"))
         self.assertIsNone(format_voter_id("800911840197"))
 
+    def test_format_voter_id_special_case(self):
+        # SP & MG voter ids can have a 9-digit sequential number, making the
+        # voter id 13 digits long. Formatting must keep every digit and place
+        # the federative union and verifying digits correctly.
+        voter_id = "3244567800167"
+        self.assertIs(is_valid(voter_id), True)
+        formatted = format_voter_id(voter_id)
+        self.assertEqual(formatted, "32445 6780 01 67")
+        self.assertEqual(formatted.replace(" ", ""), voter_id)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What this fixes

`format_voter_id` silently corrupts valid **13-digit** voter IDs (the SP/MG edge case, where the sequential number has 9 digits instead of 8).

```python
>>> from brutils import is_valid_voter_id, format_voter_id
>>> is_valid_voter_id("3244567800167")
True
>>> format_voter_id("3244567800167")
'3244 5678 00 16'   # last digit dropped; UF "00"/vd "16" are wrong (real UF=01, vd=67)
```

`is_valid` already accepts 13-digit IDs (`_is_length_valid` allows `len == 13` for UF `01`/`02`), and the parsing helpers `_get_federative_union` / `_get_verifying_digits` index backwards specifically because "the sequential_number can have eight or nine digits". Only `format_voter_id` used hardcoded 12-digit forward slices (`voter_id[:4], [4:8], [8:10], [10:12]`), so it dropped the 13th digit and misplaced the trailing fields.

## The change

Make the slicing length-aware, reusing the existing helpers: the federative union and verifying digits are always the last four characters, and the sequential number is everything before them.

- 12-digit IDs format exactly as before (`2776 2712 28 52`).
- 13-digit IDs now format losslessly (`32445 6780 01 67`), so the output minus spaces round-trips back to the input.

## Tests

Added `test_format_voter_id_special_case` using the official 13-digit fixture (`3244567800167`, already asserted valid by `test_valid_special_case`): it checks validity, the formatted output, and that the result round-trips losslessly. It fails before the change (the last digit is dropped) and passes after. Full suite: 172 tests pass; `ruff format --check` and `ruff check` clean.

I used an AI assistant to help investigate this under my direction, and I have reviewed and verified the change myself.
