### PR TITLE
fix: handle invalid legal process inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Utilitário `legal_process` [#743](https://github.com/brazilian-utils/python/pull/743)
+
 ## [2.4.0] - 2026-04-20
 
 ### Added

--- a/brutils/legal_process.py
+++ b/brutils/legal_process.py
@@ -56,7 +56,11 @@ def format_legal_process(legal_process_id: str) -> str | None:
         None
     """
 
-    if legal_process_id.isdigit() and len(legal_process_id) == 20:
+    if (
+        isinstance(legal_process_id, str)
+        and legal_process_id.isdigit()
+        and len(legal_process_id) == 20
+    ):
         capture_fields = r"(\d{7})(\d{2})(\d{4})(\d)(\d{2})(\d{4})"
         include_chars = r"\1-\2.\3.\4.\5.\6"
 
@@ -92,7 +96,16 @@ def is_valid(legal_process_id: str) -> bool:
         False
     """
 
+    if not isinstance(legal_process_id, str):
+        return False
+
     clean_legal_process_id = remove_symbols(legal_process_id)
+    if (
+        not clean_legal_process_id.isdigit()
+        or len(clean_legal_process_id) != 20
+    ):
+        return False
+
     DD = clean_legal_process_id[7:9]
     J = clean_legal_process_id[13:14]
     TR = clean_legal_process_id[14:16]

--- a/tests/test_legal_process.py
+++ b/tests/test_legal_process.py
@@ -27,6 +27,8 @@ class TestLegalProcess(TestCase):
         self.assertIsNone(format_legal_process("2314194582005507"))
         self.assertIsNone(format_legal_process("0000000000000000000000000"))
         self.assertIsNone(format_legal_process("0000000000000000000asdasd"))
+        self.assertIsNone(format_legal_process(None))
+        self.assertIsNone(format_legal_process(123))
 
     def test_remove_symbols(self):
         self.assertEqual(
@@ -73,6 +75,8 @@ class TestLegalProcess(TestCase):
         self.assertIs(is_valid("455323469202340251"), False)
         self.assertIs(is_valid("455323469202340257123123123"), False)
         self.assertIs(is_valid("455323423QQWEQWSsasd&*(()"), False)
+        self.assertIs(is_valid(None), False)
+        self.assertIs(is_valid(123), False)
         self.assertIsInstance(is_valid("455323423QQWEQWSsasd&*(()"), bool)
 
 


### PR DESCRIPTION
## Summary
- make `format_legal_process()` return `None` for non-string invalid inputs instead of raising `AttributeError`
- make `is_valid_legal_process()` return `False` before parsing non-string or non-20-digit cleaned inputs
- add regression coverage for invalid legal process inputs

## Tests
- `python -m unittest tests.test_legal_process`
- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover tests/`
- `ruff check .`
- `ruff format --check .`
- `python -m compileall -q brutils tests`
- `git diff --check`

AI assistance was used under my direction.
