### PR TITLE
chore: release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-06-30
+
 ### Added
 
 - Utilitário `generate_cnpj` com suporte a CNPJ alfanumérico [#741](https://github.com/brazilian-utils/python/pull/741)
@@ -124,7 +126,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Utilitário `cnpj.display`
 - Utilitário `cnpj.validate`
 
-[Unreleased]: https://github.com/brazilian-utils/brutils-python/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/brazilian-utils/brutils-python/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.5.0
 [2.4.0]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.4.0
 [2.3.0]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.3.0
 [2.2.0]: https://github.com/brazilian-utils/brutils-python/releases/tag/v2.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "brutils"
-version = "2.4.0"
+version = "2.5.0"
 description = "Utils library for specific Brazilian businesses"
 authors = ["The Brazilian Utils Organization"]
 license = "MIT"


### PR DESCRIPTION
### Added

- Utilitário `generate_cnpj` com suporte a CNPJ alfanumérico [#741](https://github.com/brazilian-utils/python/pull/741)

Closes #750